### PR TITLE
fix: 修复thi.props.children 循环造成的问题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 node_modules/
 npm-debug.log
 yarn-error.log
+yarn.lock
 
 # Editor directories and files
 .idea

--- a/src/components/EffectDropdown.jsx
+++ b/src/components/EffectDropdown.jsx
@@ -80,7 +80,7 @@ class EffectDropdown extends Component {
 
   render () {
     const { effect, gutter, autoHide, children } = this.props
-    const { active } = this.state;
+    const { active } = this.state
     const dropdownItemProps = {
       effect,
       gutter,
@@ -103,18 +103,6 @@ class EffectDropdown extends Component {
         </span>
 
         <ul className="effect-dropdown__content">
-          {/* props.children 在没有传入children时，是 undefined, 传入一个children时，是Object，只有2个及以上才是Array，所以直接用this.props.children去循环的话，会直接报错，是个大Bug */}
-          {/* {children.map((c, index) => {
-            const newChildrenProps = {
-              ...c.props,
-              ...dropdownItemProps,
-              key: c.key || index,
-              index,
-              handleHide: this.hide,
-            }
-
-            return React.cloneElement(c, newChildrenProps)
-          })} */}
           {React.Children.map(children, (c, index) => {
             const newChildrenProps = {
               ...c.props,
@@ -141,7 +129,7 @@ EffectDropdown.propTypes = {
   autoHide: PropTypes.bool,
   children: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.element),
-    PropTypes.object
+    PropTypes.object,
   ]),
 }
 

--- a/src/components/EffectDropdown.jsx
+++ b/src/components/EffectDropdown.jsx
@@ -80,13 +80,13 @@ class EffectDropdown extends Component {
 
   render () {
     const { effect, gutter, autoHide, children } = this.props
-    const { active } = this.state
+    const { active } = this.state;
     const dropdownItemProps = {
       effect,
       gutter,
       autoHide,
       active,
-      itemCount: children.length,
+      itemCount: React.Children.count(children),
     }
 
     return (
@@ -103,7 +103,19 @@ class EffectDropdown extends Component {
         </span>
 
         <ul className="effect-dropdown__content">
-          {children.map((c, index) => {
+          {/* props.children 在没有传入children时，是 undefined, 传入一个children时，是Object，只有2个及以上才是Array，所以直接用this.props.children去循环的话，会直接报错，是个大Bug */}
+          {/* {children.map((c, index) => {
+            const newChildrenProps = {
+              ...c.props,
+              ...dropdownItemProps,
+              key: c.key || index,
+              index,
+              handleHide: this.hide,
+            }
+
+            return React.cloneElement(c, newChildrenProps)
+          })} */}
+          {React.Children.map(children, (c, index) => {
             const newChildrenProps = {
               ...c.props,
               ...dropdownItemProps,
@@ -127,7 +139,10 @@ EffectDropdown.propTypes = {
   gutter: PropTypes.number,
   activeColor: PropTypes.string,
   autoHide: PropTypes.bool,
-  children: PropTypes.arrayOf(PropTypes.element),
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.element),
+    PropTypes.object
+  ]),
 }
 
 EffectDropdown.defaultProps = {


### PR DESCRIPTION
this.props.children 最好不要直接拿来循环，因为有可能是undefined、Object、Array，你可以试下直传入一个子元素，果断会报错的！！！